### PR TITLE
IterableQueue refactor

### DIFF
--- a/src/queutils/asyncqueue.py
+++ b/src/queutils/asyncqueue.py
@@ -19,17 +19,9 @@ from queue import Full, Empty, Queue
 from asyncio.queues import QueueEmpty, QueueFull
 import asyncio
 from typing import Generic, TypeVar
-import logging
 from asyncio import sleep
 
 T = TypeVar("T")
-
-logger = logging.getLogger(__name__)
-
-debug = logger.debug
-message = logger.warning
-verbose = logger.info
-error = logger.error
 
 
 class AsyncQueue(asyncio.Queue, Generic[T]):

--- a/src/queutils/eventcounterqueue.py
+++ b/src/queutils/eventcounterqueue.py
@@ -4,13 +4,6 @@ from deprecated import deprecated
 from .countable import Countable
 from .iterablequeue import IterableQueue, QueueDone
 from collections import defaultdict
-import logging
-
-logger = logging.getLogger()
-error = logger.error
-message = logger.warning
-verbose = logger.info
-debug = logger.debug
 
 ###########################################
 #

--- a/src/queutils/filequeue.py
+++ b/src/queutils/filequeue.py
@@ -67,9 +67,8 @@ class FileQueue(IterableQueue[Path]):
         assert isinstance(follow_symlinks, bool), "follow_symlinks has to be bool"
 
         # debug(f"maxsize={str(maxsize)}, filter='{filter}'")
-        super().__init__(count_items=True, **kwargs)
+        super().__init__(**kwargs)
         self._base: Optional[Path] = base
-        # self._done: bool = False
         self._case_sensitive: bool = False
         self._exclude: bool = False
         self._follow_symlinks: bool = follow_symlinks

--- a/src/queutils/filequeue.py
+++ b/src/queutils/filequeue.py
@@ -47,8 +47,8 @@ def str2path(filename: str | Path, suffix: str | None = None) -> Path:
 
 class FileQueue(IterableQueue[Path]):
     """
-    Class to create a IterableQueue(asyncio.Queue) of filenames based on 
-    given directories and files as arguments. 
+    Class to create a IterableQueue(asyncio.Queue) of filenames based on
+    given directories and files as arguments.
     Supports include/exclude filters based on filenames.
     """
 
@@ -58,21 +58,21 @@ class FileQueue(IterableQueue[Path]):
         filter: str = "*",
         exclude: bool = False,
         case_sensitive: bool = True,
-        follow_symlinks: bool = False, 
+        follow_symlinks: bool = False,
         **kwargs,
     ):
         assert base is None or isinstance(base, Path), "base has to be Path or None"
         assert isinstance(filter, str), "filter has to be string"
         assert isinstance(case_sensitive, bool), "case_sensitive has to be bool"
         assert isinstance(follow_symlinks, bool), "follow_symlinks has to be bool"
-        
+
         # debug(f"maxsize={str(maxsize)}, filter='{filter}'")
         super().__init__(count_items=True, **kwargs)
         self._base: Optional[Path] = base
         # self._done: bool = False
         self._case_sensitive: bool = False
         self._exclude: bool = False
-        self._follow_symlinks : bool = follow_symlinks
+        self._follow_symlinks: bool = follow_symlinks
         self.set_filter(filter=filter, exclude=exclude, case_sensitive=case_sensitive)
 
     def set_filter(
@@ -119,8 +119,7 @@ class FileQueue(IterableQueue[Path]):
                     await self.put(path)
         except Exception as err:
             error(f"{err}")
-        return await self.finish()
-
+        return await self.finish_producer()
 
     async def put(self, path: Path) -> None:
         """Recursive function to build process queue. Sanitize filename"""

--- a/src/queutils/filequeue.py
+++ b/src/queutils/filequeue.py
@@ -29,8 +29,6 @@ from .iterablequeue import IterableQueue
 
 logger = logging.getLogger(__name__)
 error = logger.error
-message = logger.warning
-verbose = logger.info
 debug = logger.debug
 
 

--- a/src/queutils/iterablequeue.py
+++ b/src/queutils/iterablequeue.py
@@ -200,14 +200,12 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
             if self._producers <= 0:
                 raise ValueError("No registered producers")
             await self._Q.put(item=item)
-        # self._empty.clear()
         return None
 
     def put_nowait(self, item: T) -> None:
         """
         Experimental asyncio.Queue.put_nowait() implementation
         """
-        # raise NotImplementedError
         if self.is_filled:
             raise QueueDone
         if self._producers <= 0:
@@ -215,7 +213,6 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
         if item is None:
             raise ValueError("Cannot add None to IterableQueue")
         self._Q.put_nowait(item=item)
-        # self._empty.clear()
         return None
 
     async def get(self) -> T:
@@ -229,7 +226,6 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
                 await self._Q.put(None)
                 raise QueueDone
         else:
-            # async with self._modify:
             self._wip += 1
             return item
 
@@ -279,7 +275,6 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
         """
         Async iterator for IterableQueue
         """
-        # async with self._modify:
         if self._wip > 0:  # do not mark task_done() at first call
             self.task_done()
         try:

--- a/src/queutils/iterablequeue.py
+++ b/src/queutils/iterablequeue.py
@@ -140,7 +140,8 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
         """
         Add producer(s) to the queue
         """
-        assert N > 0, "N has to be positive"
+        if N <= 0:
+            raise ValueError("N has to be positive")
         async with self._modify:
             if self.is_filled:
                 raise QueueDone

--- a/src/queutils/iterablequeue.py
+++ b/src/queutils/iterablequeue.py
@@ -57,12 +57,11 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
     want to sum the count of multiple IterableQueues
     """
 
-    def __init__(self, count_items: bool = True, **kwargs):
+    def __init__(self, **kwargs) -> None:
         # _Q is required instead of inheriting from Queue()
         # using super() since Queue is Optional[T], not [T]
         self._Q: Queue[Optional[T]] = Queue(**kwargs)
         self._producers: int = 0
-        self._count_items: bool = count_items
         self._count: int = 0
         self._wip: int = 0
 
@@ -138,10 +137,7 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
 
     @property
     def count(self) -> int:
-        if self._count_items:
-            return self._count
-        else:
-            return 0
+        return self._count
 
     async def add_producer(self, N: int = 1) -> int:
         """

--- a/src/queutils/iterablequeue.py
+++ b/src/queutils/iterablequeue.py
@@ -65,6 +65,7 @@ class IterableQueue(Queue[T], AsyncIterable[T], Countable):
         # _Q is required instead of inheriting from Queue()
         # using super() since Queue is Optional[T], not [T]
         self._Q: Queue[Optional[T]] = Queue(**kwargs)
+        self._maxsize: int = self._Q.maxsize  # Asyncio.Queue has _maxsize
         self._producers: int = 0
         self._count: int = 0
         self._wip: int = 0

--- a/tests/test_awrap.py
+++ b/tests/test_awrap.py
@@ -16,7 +16,7 @@ async def _producer_int(
             await Q.put(i)
     except QueueDone:
         raise ValueError("Queue is done even no one closed it")
-    await Q.finish()
+    await Q.finish_producer()
     return None
 
 

--- a/tests/test_eventcounterqueue.py
+++ b/tests/test_eventcounterqueue.py
@@ -54,7 +54,7 @@ async def test_1_category_counter_queue(
             count: int = randint(1, 10)
             await Q.send(cat, count)
             _counter[cat] += count
-        await Q.finish()
+        await Q.finish_producer()
         return _counter
 
     senders: list[Task] = list()

--- a/tests/test_iterablequeue.py
+++ b/tests/test_iterablequeue.py
@@ -79,7 +79,7 @@ async def test_1_put_get_async(test_interablequeue_int: IterableQueue[int]):
         async with timeout(TIMEOUT / 2):
             await Q.join()
         await Q.get()
-        assert False, "Queue is done and put() should raise an exception"
+        assert False, "Queue is done and get() should raise an exception"
     except TimeoutError:
         assert False, "IterableQueue.join() took too long"
     except QueueDone:


### PR DESCRIPTION
### `IterableQueue()`

- Rename `finish()` => `finish_producer()`
- Remove unnecessary locks and checks
- More exhaustive tests
- add `_maxsize` attribute since the parent `asyncio.Queue` has it